### PR TITLE
Update funnel outlier flagging

### DIFF
--- a/qiverse.qipatterns/DESCRIPTION
+++ b/qiverse.qipatterns/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: qiverse.qipatterns
 Title: Quality Improvement Chart Patterns
-Version: 0.1.1.0
+Version: 0.1.2
 Authors@R:
     person(given = "Healthcare Quality Intelligence Unit (Western Australia Health)",
     family = "",

--- a/qiverse.qipatterns/R/Append_fpl_val.R
+++ b/qiverse.qipatterns/R/Append_fpl_val.R
@@ -106,9 +106,9 @@ append_fpl_val <- function(
                      better_is = better_is[1])]
 
   #Check which points are outliers
-  funnel_data[better_is == "Lower" & fpl_row_value >= fpl_ul99,
+  funnel_data[better_is == "Lower" & fpl_row_value > fpl_ul99,
               fpl_astro := period_end[1]][
-                better_is == "Higher" & fpl_row_value <= fpl_ll99,
+                better_is == "Higher" & fpl_row_value < fpl_ll99,
                 fpl_astro := period_end[1]]
   #remove better_is field
   funnel_data[, better_is := NULL]

--- a/qiverse.qiplotly/DESCRIPTION
+++ b/qiverse.qiplotly/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: qiverse.qiplotly
 Title: Quality Improvement Plotly Charts
-Version: 0.1.2.3
+Version: 0.1.3
 Authors@R:
     person(given = "Healthcare Quality Intelligence Unit (Western Australia Health)",
     family = "",

--- a/qiverse.qiplotly/R/Plotly_funnel.R
+++ b/qiverse.qiplotly/R/Plotly_funnel.R
@@ -324,7 +324,7 @@ fpl_plotly_create <- function(
   ## Flag 3 sigma outliers
   funnel_data <- funnel_data |>
     dplyr::mutate(outlier_3sigma = ifelse(
-      rr * multiplier >= UCL99 | rr * multiplier <= LCL99,
+      rr * multiplier > UCL99 | rr * multiplier < LCL99,
       1, 0
     ))
 


### PR DESCRIPTION
Funnel plot outliers should be flagged based on `>` or `<` limits, rather than `>=` or `<=`