### PR TITLE
Update Snowflake Ingest function

### DIFF
--- a/qiverse.snowflake/DESCRIPTION
+++ b/qiverse.snowflake/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: qiverse.snowflake
 Title: Snowflake Connectivity
-Version: 0.0.1.0
+Version: 0.0.2.0
 Authors@R:
     person(given = "Healthcare Quality Intelligence Unit (Western Australia Health)",
     family = "",

--- a/qiverse.snowflake/R/snowflake.R
+++ b/qiverse.snowflake/R/snowflake.R
@@ -107,11 +107,6 @@ ingest_to_snowflake <- function(
     DBI::dbGetQuery(con, DBI::SQL(paste0("USE WAREHOUSE ", warehouse_name, ";")))
   }
 
-  # Create schema in Snowflake ####
-  DBI::dbGetQuery(con, DBI::SQL(paste0(
-    "create schema IF NOT EXISTS ", database_name, ".", schema_name
-  )))
-
   # Set Data Type in SQL ####
   sql_data_type <- DBI::dbDataType(con, input_data)
   # Convert those with character lengths greater than 255, to be the maximum

--- a/qiverse.snowflake/man/ingest_to_snowflake.Rd
+++ b/qiverse.snowflake/man/ingest_to_snowflake.Rd
@@ -4,7 +4,15 @@
 \alias{ingest_to_snowflake}
 \title{Ingest table into Snowflake}
 \usage{
-ingest_to_snowflake(data, con, database_name, schema_name, table_name)
+ingest_to_snowflake(
+  data,
+  con,
+  database_name,
+  schema_name,
+  table_name,
+  role_name = NULL,
+  warehouse_name = NULL
+)
 }
 \arguments{
 \item{data}{This is the R object that we are importing into snowflake.
@@ -17,6 +25,12 @@ This must be a data.frame, data.table or tibble.}
 \item{schema_name}{The schema for the table to be stored.}
 
 \item{table_name}{The name of the table for Snowflake}
+
+\item{role_name}{The role to use for the session. If NULL, no role is set
+and the user account the default is used.}
+
+\item{warehouse_name}{The warehouse to use for the session. If NULL, no
+warehouse is set and the user account the default is used.}
 }
 \value{
 A data.frame with output metadata on the ingestion process.


### PR DESCRIPTION
Update the `qiverse.snowflake` function for `ingest_to_snowflake` to add optional parameters for setting role and warehouse, and removing the create schema step. The schema will need to be created in advance for the function to successfully ingest an R data.frame as a table into Snowflake.