### PR TITLE
Fix bugs relating to qiverse.qimisc SR charts

### DIFF
--- a/qiverse.qimisc/DESCRIPTION
+++ b/qiverse.qimisc/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: qiverse.qimisc
 Title: Multiple Indicator Sigma Chart
-Version: 0.0.1.1
+Version: 0.0.1.2
 Authors@R:
     person(given = "Healthcare Quality Intelligence Unit (Western Australia Health)",
     family = "",

--- a/qiverse.qimisc/R/misc_plotly.R
+++ b/qiverse.qimisc/R/misc_plotly.R
@@ -64,6 +64,9 @@ misc_plotly <- function(data,
   ### Set blank for others
   data[is.na(suffix), suffix := ""]
 
+  ## Set centerline to 100 for SR data type
+  data[data_type == "SR", cl := 100]
+
   #see my comment on the hovertext below
   data[, hovertext := paste0(
     "<br><b>", indicator_theme, ": ", indicator, "</b>",

--- a/qiverse.qimisc/R/misc_prep_data.R
+++ b/qiverse.qimisc/R/misc_prep_data.R
@@ -104,7 +104,7 @@ misc_prep_data <- function(funnel_data, indicator_data) {
       }
 
       # Extract out values , Uzscore, control limits
-      funnel_data <- funnel$aggregated_data[, c("group", "Uzscore",
+      funnel_data <- funnel$aggregated_data[, c("group", "Wuzscore", "Uzscore",
                                                 "LCL99", "UCL99",
                                                 "OD99LCL", "OD99UCL",  "s")] |>
         data.table::as.data.table()
@@ -135,6 +135,11 @@ misc_prep_data <- function(funnel_data, indicator_data) {
                     LCL99 = LCL99 * 100,
                     OD99LCL = OD99LCL * 100,
                     OD99UCL = OD99UCL * 100)]
+
+  # Apply winsorisation fix for data_type SR
+  ## As the SR method is CQC which uses winsorisation, need to use the Wuzscore instead of the Uzscore
+  data_funnel[data_type == "SR", Uzscore := Wuzscore]
+  data_funnel[, Wuzscore := NULL]
 
   # Apply overdispersion
   # calculating Z score for over dispersion


### PR DESCRIPTION
For the `qiverse.qimisc` package, this PR fixes a couple of bugs:

- The SR data type uses the CQC method, which requires usage of the winsorised Uzscore. The MISC chart now uses the WUzscore column for SR data types.
- The MISC plotly rendering calculated the average for the centerline. This is now replaced by 100 where the data type is SR.