### PR TITLE
Handle zero numerator for SR funnel charts in qiverse.qimisc

### DIFF
--- a/qiverse.qimisc/DESCRIPTION
+++ b/qiverse.qimisc/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: qiverse.qimisc
 Title: Multiple Indicator Sigma Chart
-Version: 0.0.1.2
+Version: 0.0.1.3
 Authors@R:
     person(given = "Healthcare Quality Intelligence Unit (Western Australia Health)",
     family = "",

--- a/qiverse.qimisc/R/misc_prep_data.R
+++ b/qiverse.qimisc/R/misc_prep_data.R
@@ -163,6 +163,9 @@ misc_prep_data <- function(funnel_data, indicator_data) {
     rr = rr,
     denominator = denominator
   )]
+  ## Handle infinite z-scores (when rr = 0)
+  data_funnel[data_type == "SR" & overdispersion == FALSE & rr == 0 &
+                is.infinite(Uzscore) & Uzscore < 0, Uzscore := -99]
   data_funnel[, rr := NULL]
 
   # Apply overdispersion

--- a/qiverse.qimisc/R/misc_prep_data.R
+++ b/qiverse.qimisc/R/misc_prep_data.R
@@ -34,7 +34,7 @@ misc_prep_data <- function(funnel_data, indicator_data) {
     numerator <- denominator <- value <- multiplier <- betteris <-
     Uzscore_betteris <- Uzscore <- data_type <- suffix <- UCL99 <- LCL99 <-
     OD99LCL <- OD99UCL <- s <- ODUzscore <- #nolint
-    `:=`  <- .N <- overdispersion <- NULL #nolint
+    `:=`  <- .N <- overdispersion <- rr <- NULL #nolint
 
   #  not sure if order of the functions matters, I suspect it doesn't, but the order of the functions is different betwen misc_plotly() and misc_prep_data()
   # Load Data
@@ -151,11 +151,11 @@ misc_prep_data <- function(funnel_data, indicator_data) {
     offset <- ifelse(rr > 1, 1, 0)
 
     # Map the observed ratio to a probability (in [0-1]) via the Chi-Square CDF
-    log_p <- pchisq(rr * 2 * denominator, 2 * (denominator + offset), log.p = TRUE)
+    log_p <- stats::pchisq(rr * 2 * denominator, 2 * (denominator + offset), log.p = TRUE)
 
     # Use the standard-normal quantile function to map the probability to
     #  a z-score
-    qnorm(log_p, log.p = TRUE)
+    stats::qnorm(log_p, log.p = TRUE)
   }
 
   # Map the SR Ratios to z-scores


### PR DESCRIPTION
Zero numerator groups in SR funnel charts have a -Inf calculated zscore. This PR updates this to be a large negative number, allowing for the bar to be generated in the plot.

@NMHS-MikikoChono-Schaa just wanted to check with you if this is how you want it to be handled, before merging in.