### PR TITLE
Fix powerbi get_pbi_cluster_details

### DIFF
--- a/qiverse.powerbi/R/utilities.R
+++ b/qiverse.powerbi/R/utilities.R
@@ -180,7 +180,7 @@ decompress_string <- function(compressed_string) {
 
 # Query the cluster resolve endpoint to get XMLA server details for a given capacity (needed for querying datasets)
 get_pbi_cluster_details <- function(capacity_id, access_token) {
-  httr::POST("https://australiasoutheast.pbidedicated.windows.net/webapi/clusterResolve",
+  httr::POST("https://australiaeast.pbidedicated.windows.net/webapi/clusterResolve",
               config = get_auth_header(access_token),
               body = jsonlite::toJSON(list(
                 databaseName = NA,


### PR DESCRIPTION
@andrjohns Found the issue with the XMLA method, the region is now changing so this line of code just needs to be updated to reflect this. The real way to fix would be to actually read in the capacity details (i.e. using [Get Capacities](https://learn.microsoft.com/en-us/rest/api/power-bi/capacities/get-capacities)), but this will work for now.

Will leave as a PR for now until after the capacities have migrated.