### PR TITLE
Param for update databricks secret

### DIFF
--- a/qiverse.azure/DESCRIPTION
+++ b/qiverse.azure/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: qiverse.azure
 Title: PowerBI, Sharepoint and Snowflake Connectivity
-Version: 0.0.3
+Version: 0.0.4
 Authors@R:
     person(given = "Healthcare Quality Intelligence Unit (Western Australia Health)",
     family = "",
@@ -26,3 +26,4 @@ Suggests:
 Remotes:
 VignetteBuilder: knitr
 Config/roxygen2/version: 8.0.0
+RoxygenNote: 7.3.3

--- a/qiverse.azure/R/databricks_secrets.R
+++ b/qiverse.azure/R/databricks_secrets.R
@@ -164,18 +164,20 @@ store_databricks_access_token <- function(token, url, username) {
 #' secret in the specified workspace under your username.
 #'
 #' @param workspace_url The workspace URL of the databricks instance
+#' @param app_id The App ID used to authenticate to. Default is the App ID for
+#' Excel for PowerQuery.
 #'
 #' @return NULL
 #'
 #' @family Azure methods
 #' @export
-update_databricks_token <- function(workspace_url) {
+update_databricks_token <- function(workspace_url, app_id = "a672d62c-fc7b-4e81-a576-e60dc46e951d") {
   db_token <- AzureAuth::get_azure_token(
     # Default resource ID for Azure Databricks
     resource = "2ff814a6-3304-4ab8-85cb-cd0e6f879c1d",
     tenant = "common",
     # App ID for Excel for PowerQuery
-    app = "a672d62c-fc7b-4e81-a576-e60dc46e951d",
+    app = app_id,
     # Ensure that token has MFA claim for usage outside of corporate network
     token_args = list(claims = '{"access_token":{"amr":{"values":["mfa"]}}}'),
     use_cache = FALSE

--- a/qiverse.azure/man/az_authenticated_api_query.Rd
+++ b/qiverse.azure/man/az_authenticated_api_query.Rd
@@ -26,10 +26,10 @@ Make a call to a web API which requires an Azure access token for
 authentication
 }
 \seealso{
-Other Azure methods:
-\code{\link[=db_secret_scopes_api]{db_secret_scopes_api()}},
-\code{\link[=db_secrets_api]{db_secrets_api()}},
-\code{\link[=store_databricks_access_token]{store_databricks_access_token()}},
-\code{\link[=update_databricks_token]{update_databricks_token()}}
+Other Azure methods: 
+\code{\link{db_secret_scopes_api}()},
+\code{\link{db_secrets_api}()},
+\code{\link{store_databricks_access_token}()},
+\code{\link{update_databricks_token}()}
 }
 \concept{Azure methods}

--- a/qiverse.azure/man/db_secret_scopes_api.Rd
+++ b/qiverse.azure/man/db_secret_scopes_api.Rd
@@ -29,10 +29,10 @@ Interact with the Databricks API for managing secret scopes
 and deleting secret scopes.
 }
 \seealso{
-Other Azure methods:
-\code{\link[=az_authenticated_api_query]{az_authenticated_api_query()}},
-\code{\link[=db_secrets_api]{db_secrets_api()}},
-\code{\link[=store_databricks_access_token]{store_databricks_access_token()}},
-\code{\link[=update_databricks_token]{update_databricks_token()}}
+Other Azure methods: 
+\code{\link{az_authenticated_api_query}()},
+\code{\link{db_secrets_api}()},
+\code{\link{store_databricks_access_token}()},
+\code{\link{update_databricks_token}()}
 }
 \concept{Azure methods}

--- a/qiverse.azure/man/db_secrets_api.Rd
+++ b/qiverse.azure/man/db_secrets_api.Rd
@@ -43,10 +43,10 @@ The Databricks API allows for listing, creating,
 and deleting secret scopes.
 }
 \seealso{
-Other Azure methods:
-\code{\link[=az_authenticated_api_query]{az_authenticated_api_query()}},
-\code{\link[=db_secret_scopes_api]{db_secret_scopes_api()}},
-\code{\link[=store_databricks_access_token]{store_databricks_access_token()}},
-\code{\link[=update_databricks_token]{update_databricks_token()}}
+Other Azure methods: 
+\code{\link{az_authenticated_api_query}()},
+\code{\link{db_secret_scopes_api}()},
+\code{\link{store_databricks_access_token}()},
+\code{\link{update_databricks_token}()}
 }
 \concept{Azure methods}

--- a/qiverse.azure/man/dot-init_key_vault.Rd
+++ b/qiverse.azure/man/dot-init_key_vault.Rd
@@ -23,11 +23,11 @@ an AzureAuth access token object is not provided then the authentication
 process is also initiated
 }
 \seealso{
-Other Key Vault methods:
-\code{\link[=.secrets_operation]{.secrets_operation()}},
-\code{\link[=kv_delete_secret]{kv_delete_secret()}},
-\code{\link[=kv_get_secret]{kv_get_secret()}},
-\code{\link[=kv_list_secrets]{kv_list_secrets()}},
-\code{\link[=kv_write_secret]{kv_write_secret()}}
+Other Key Vault methods: 
+\code{\link{.secrets_operation}()},
+\code{\link{kv_delete_secret}()},
+\code{\link{kv_get_secret}()},
+\code{\link{kv_list_secrets}()},
+\code{\link{kv_write_secret}()}
 }
 \concept{Key Vault methods}

--- a/qiverse.azure/man/dot-secrets_operation.Rd
+++ b/qiverse.azure/man/dot-secrets_operation.Rd
@@ -30,11 +30,11 @@ secrets. Handles the connection and authentication (if necessary) to the
 Key Vault service
 }
 \seealso{
-Other Key Vault methods:
-\code{\link[=.init_key_vault]{.init_key_vault()}},
-\code{\link[=kv_delete_secret]{kv_delete_secret()}},
-\code{\link[=kv_get_secret]{kv_get_secret()}},
-\code{\link[=kv_list_secrets]{kv_list_secrets()}},
-\code{\link[=kv_write_secret]{kv_write_secret()}}
+Other Key Vault methods: 
+\code{\link{.init_key_vault}()},
+\code{\link{kv_delete_secret}()},
+\code{\link{kv_get_secret}()},
+\code{\link{kv_list_secrets}()},
+\code{\link{kv_write_secret}()}
 }
 \concept{Key Vault methods}

--- a/qiverse.azure/man/kv_delete_secret.Rd
+++ b/qiverse.azure/man/kv_delete_secret.Rd
@@ -21,11 +21,11 @@ created for the Key Vault resource}
 Delete a specified secret from a given Key Vault
 }
 \seealso{
-Other Key Vault methods:
-\code{\link[=.init_key_vault]{.init_key_vault()}},
-\code{\link[=.secrets_operation]{.secrets_operation()}},
-\code{\link[=kv_get_secret]{kv_get_secret()}},
-\code{\link[=kv_list_secrets]{kv_list_secrets()}},
-\code{\link[=kv_write_secret]{kv_write_secret()}}
+Other Key Vault methods: 
+\code{\link{.init_key_vault}()},
+\code{\link{.secrets_operation}()},
+\code{\link{kv_get_secret}()},
+\code{\link{kv_list_secrets}()},
+\code{\link{kv_write_secret}()}
 }
 \concept{Key Vault methods}

--- a/qiverse.azure/man/kv_get_secret.Rd
+++ b/qiverse.azure/man/kv_get_secret.Rd
@@ -21,11 +21,11 @@ The value of a secret stored in the given Key Vault
 Retrieve the value of a specified secret from a given Key Vault
 }
 \seealso{
-Other Key Vault methods:
-\code{\link[=.init_key_vault]{.init_key_vault()}},
-\code{\link[=.secrets_operation]{.secrets_operation()}},
-\code{\link[=kv_delete_secret]{kv_delete_secret()}},
-\code{\link[=kv_list_secrets]{kv_list_secrets()}},
-\code{\link[=kv_write_secret]{kv_write_secret()}}
+Other Key Vault methods: 
+\code{\link{.init_key_vault}()},
+\code{\link{.secrets_operation}()},
+\code{\link{kv_delete_secret}()},
+\code{\link{kv_list_secrets}()},
+\code{\link{kv_write_secret}()}
 }
 \concept{Key Vault methods}

--- a/qiverse.azure/man/kv_list_secrets.Rd
+++ b/qiverse.azure/man/kv_list_secrets.Rd
@@ -19,11 +19,11 @@ A list of the (names of) secrets stored in the given Key Vault
 List the names of secrets stored in a given Azure Key Vault
 }
 \seealso{
-Other Key Vault methods:
-\code{\link[=.init_key_vault]{.init_key_vault()}},
-\code{\link[=.secrets_operation]{.secrets_operation()}},
-\code{\link[=kv_delete_secret]{kv_delete_secret()}},
-\code{\link[=kv_get_secret]{kv_get_secret()}},
-\code{\link[=kv_write_secret]{kv_write_secret()}}
+Other Key Vault methods: 
+\code{\link{.init_key_vault}()},
+\code{\link{.secrets_operation}()},
+\code{\link{kv_delete_secret}()},
+\code{\link{kv_get_secret}()},
+\code{\link{kv_write_secret}()}
 }
 \concept{Key Vault methods}

--- a/qiverse.azure/man/kv_write_secret.Rd
+++ b/qiverse.azure/man/kv_write_secret.Rd
@@ -29,11 +29,11 @@ created for the Key Vault resource}
 Create or overwrite a secret in an Azure Key Vault
 }
 \seealso{
-Other Key Vault methods:
-\code{\link[=.init_key_vault]{.init_key_vault()}},
-\code{\link[=.secrets_operation]{.secrets_operation()}},
-\code{\link[=kv_delete_secret]{kv_delete_secret()}},
-\code{\link[=kv_get_secret]{kv_get_secret()}},
-\code{\link[=kv_list_secrets]{kv_list_secrets()}}
+Other Key Vault methods: 
+\code{\link{.init_key_vault}()},
+\code{\link{.secrets_operation}()},
+\code{\link{kv_delete_secret}()},
+\code{\link{kv_get_secret}()},
+\code{\link{kv_list_secrets}()}
 }
 \concept{Key Vault methods}

--- a/qiverse.azure/man/store_databricks_access_token.Rd
+++ b/qiverse.azure/man/store_databricks_access_token.Rd
@@ -48,10 +48,10 @@ if(update_secret$status_code == 200) {
 }
 }
 \seealso{
-Other Azure methods:
-\code{\link[=az_authenticated_api_query]{az_authenticated_api_query()}},
-\code{\link[=db_secret_scopes_api]{db_secret_scopes_api()}},
-\code{\link[=db_secrets_api]{db_secrets_api()}},
-\code{\link[=update_databricks_token]{update_databricks_token()}}
+Other Azure methods: 
+\code{\link{az_authenticated_api_query}()},
+\code{\link{db_secret_scopes_api}()},
+\code{\link{db_secrets_api}()},
+\code{\link{update_databricks_token}()}
 }
 \concept{Azure methods}

--- a/qiverse.azure/man/update_databricks_token.Rd
+++ b/qiverse.azure/man/update_databricks_token.Rd
@@ -4,20 +4,26 @@
 \alias{update_databricks_token}
 \title{Refresh Databricks Azure Token Secret}
 \usage{
-update_databricks_token(workspace_url)
+update_databricks_token(
+  workspace_url,
+  app_id = "a672d62c-fc7b-4e81-a576-e60dc46e951d"
+)
 }
 \arguments{
 \item{workspace_url}{The workspace URL of the databricks instance}
+
+\item{app_id}{The App ID used to authenticate to. Default is the App ID for
+Excel for PowerQuery.}
 }
 \description{
 Generates a new Azure access token and stores it as a Databricks
 secret in the specified workspace under your username.
 }
 \seealso{
-Other Azure methods:
-\code{\link[=az_authenticated_api_query]{az_authenticated_api_query()}},
-\code{\link[=db_secret_scopes_api]{db_secret_scopes_api()}},
-\code{\link[=db_secrets_api]{db_secrets_api()}},
-\code{\link[=store_databricks_access_token]{store_databricks_access_token()}}
+Other Azure methods: 
+\code{\link{az_authenticated_api_query}()},
+\code{\link{db_secret_scopes_api}()},
+\code{\link{db_secrets_api}()},
+\code{\link{store_databricks_access_token}()}
 }
 \concept{Azure methods}


### PR DESCRIPTION
Tagging @andrjohns for review since you originally wrote this function.

I've made a minor change to allow the App ID for the `update_databricks_token` to be a parameter that feeds into the function, to allow greater flexibility in which client we are requesting the authorisation from.

I found that the default App ID for Excel for PowerQuery is causing errors, so this allowed me to change it to the Microsoft Azure Powershell ID which worked.