### PR TITLE
qiverse.powerbi: Automatically create access token

### DIFF
--- a/qiverse.powerbi/DESCRIPTION
+++ b/qiverse.powerbi/DESCRIPTION
@@ -19,10 +19,12 @@ Imports:
   jsonlite,
   xml2
 Suggests:
+  qiverse.azure,
   arrow,
   zlib,
   knitr,
   rmarkdown,
   testthat (>= 3.0.0)
 VignetteBuilder: knitr
-Config/roxygen2/version: 8.0.0
+Config/roxygen2/version: 8.1.0
+Additional_repositories: https://aus-doh-safety-and-quality.r-universe.dev/

--- a/qiverse.powerbi/NAMESPACE
+++ b/qiverse.powerbi/NAMESPACE
@@ -12,14 +12,18 @@ export(list_workspaces)
 export(refresh_dataflow)
 export(update_dataflow_compute_engine)
 export(update_dataset_storage_mode)
-importFrom(httr,GET)
-importFrom(httr,POST)
-importFrom(httr,add_headers)
-importFrom(httr,content)
-importFrom(httr,content_type_json)
+importFrom(httr,
+  GET,
+  POST,
+  add_headers,
+  content,
+  content_type_json
+)
 importFrom(jsonlite,toJSON)
-importFrom(xml2,xml_attr)
-importFrom(xml2,xml_children)
-importFrom(xml2,xml_find_all)
-importFrom(xml2,xml_name)
-importFrom(xml2,xml_text)
+importFrom(xml2,
+  xml_attr,
+  xml_children,
+  xml_find_all,
+  xml_name,
+  xml_text
+)

--- a/qiverse.powerbi/R/datasets.R
+++ b/qiverse.powerbi/R/datasets.R
@@ -1,12 +1,16 @@
 #' Request metadata for all datasets in specified workspace
 #'
 #' @param workspace Name of the workspace containing datasets
-#' @param access_token The token generated with the correct PowerBI Dataset
-#' permissions. Use get_az_tk('pbi_ds') to create this token.
-#'
+#' @param access_token Token for authorising the connection to PowerBI. Valid options are:
+#' \itemize{
+#' \item `NULL`(default): Automatically generate via `qiverse.azure::get_az_tk('pbi_df')`
+#' \item An `AzureAuth` object: Will be refreshed for the `https://analysis.windows.net/powerbi/api` resource
+#' \item A single string specifying the access token
+#'}
 #' @return DataFrame containing the names, GUIDs, and descriptions for all datasets in workspace
 #' @export
-list_datasets <- function(workspace, access_token) {
+list_datasets <- function(workspace, access_token = NULL) {
+  access_token <- init_access_token(access_token)
   workspace_metadata <- list_workspaces(access_token)
   if (!(workspace %in% workspace_metadata$Workspace)) {
     stop("No workspace called: ", workspace, " in tenant!", call. = FALSE)
@@ -57,14 +61,19 @@ list_datasets <- function(workspace, access_token) {
 #' @param dataset Name of the dataset containing table
 #' @param table Name of the table to download
 #' @param method The API to use for downloading the table. Valid values are "XMLA" (the default) and "REST"
-#' @param access_token The token generated with the correct PowerBI Dataset
-#' permissions. Use get_az_tk('pbi_ds') to create this token.
+#' @param access_token Token for authorising the connection to PowerBI. Valid options are:
+#' \itemize{
+#' \item `NULL`(default): Automatically generate via `qiverse.azure::get_az_tk('pbi_df')`
+#' \item An `AzureAuth` object: Will be refreshed for the `https://analysis.windows.net/powerbi/api` resource
+#' \item A single string specifying the access token
+#'}
 #'
 #' @return DataFrame containing downloaded table
 #' @export
 download_dataset_table <- function(workspace, dataset, table,
                               method = "XMLA",
-                              access_token) {
+                              access_token = NULL) {
+  access_token <- init_access_token(access_token)
   query <- paste0("EVALUATE('", table, "')")
   if (method == "XMLA") {
     table_query <- execute_xmla_query(workspace, dataset, query, access_token)
@@ -83,12 +92,17 @@ download_dataset_table <- function(workspace, dataset, table,
 #' @param workspace Name of the workspace containing dataflow
 #' @param dataset Name of the dataset to execute query against
 #' @param query DAX query to execute
-#' @param access_token The token generated with the correct PowerBI Dataset
-#' permissions. Use get_az_tk('pbi_ds') to create this token.
+#' @param access_token Token for authorising the connection to PowerBI. Valid options are:
+#' \itemize{
+#' \item `NULL`(default): Automatically generate via `qiverse.azure::get_az_tk('pbi_df')`
+#' \item An `AzureAuth` object: Will be refreshed for the `https://analysis.windows.net/powerbi/api` resource
+#' \item A single string specifying the access token
+#'}
 #'
 #' @return DataFrame containing results of query
 #' @export
-execute_rest_query <- function(workspace, dataset, query, access_token) {
+execute_rest_query <- function(workspace, dataset, query, access_token = NULL) {
+  access_token <- init_access_token(access_token)
   dataset_metadata <- list_datasets(workspace, access_token)
   if (!(dataset %in% dataset_metadata$Dataset)) {
     stop("No dataset called: ", dataset, "in workspace: ", workspace, "!", call. = FALSE)
@@ -110,12 +124,17 @@ execute_rest_query <- function(workspace, dataset, query, access_token) {
 #' @param workspace Name of the workspace containing dataflow
 #' @param dataset Name of the dataset to execute query against
 #' @param query DAX query to execute
-#' @param access_token The token generated with the correct PowerBI Dataset
-#' permissions. Use get_az_tk('pbi_ds') to create this token.
+#' @param access_token Token for authorising the connection to PowerBI. Valid options are:
+#' \itemize{
+#' \item `NULL`(default): Automatically generate via `qiverse.azure::get_az_tk('pbi_df')`
+#' \item An `AzureAuth` object: Will be refreshed for the `https://analysis.windows.net/powerbi/api` resource
+#' \item A single string specifying the access token
+#'}
 #'
 #' @return DataFrame containing results of query
 #' @export
-execute_arrow_query <- function(workspace, dataset, query, access_token) {
+execute_arrow_query <- function(workspace, dataset, query, access_token = NULL) {
+  access_token <- init_access_token(access_token)
   if (!("arrow" %in% utils::installed.packages()[,"Package"])) {
     stop("This function requires the 'arrow' package, but it is not installed!")
   }
@@ -131,7 +150,8 @@ execute_arrow_query <- function(workspace, dataset, query, access_token) {
   execute_arrow_query_impl(workspace_id, dataset_id, query, access_token)
 }
 
-execute_arrow_query_impl <- function(workspace_id, dataset_id, query, access_token) {
+execute_arrow_query_impl <- function(workspace_id, dataset_id, query, access_token = NULL) {
+  access_token <- init_access_token(access_token)
   query_url <- paste0("https://api.powerbi.com/v1.0/myorg/groups/", workspace_id, "/datasets/", dataset_id, "/executeDaxQueries")
 
   arrow_query <- httr::POST(
@@ -159,7 +179,8 @@ execute_arrow_query_impl <- function(workspace_id, dataset_id, query, access_tok
     clean_dataset_names()
 }
 
-execute_rest_query_impl <- function(dataset_id, query, access_token) {
+execute_rest_query_impl <- function(dataset_id, query, access_token = NULL) {
+  access_token <- init_access_token(access_token)
   query_url <- paste0("https://api.powerbi.com/v1.0/myorg/datasets/", dataset_id, "/executeQueries")
 
   rest_query <- httr::POST(url = query_url,
@@ -220,13 +241,17 @@ execute_xmla_query_impl <- function(cluster_url, xmla_server, dataset, query,
 #' @param workspace Name of the workspace containing dataflow
 #' @param dataset Name of the dataset to execute query against
 #' @param query DAX query to execute
-#' @param access_token The token generated with the correct PowerBI Dataset
-#' permissions. Use get_az_tk('pbi_df') or get_az_tk('pbi_df') to create
-#' this token.
+#' @param access_token Token for authorising the connection to PowerBI. Valid options are:
+#' \itemize{
+#' \item `NULL`(default): Automatically generate via `qiverse.azure::get_az_tk('pbi_df')`
+#' \item An `AzureAuth` object: Will be refreshed for the `https://analysis.windows.net/powerbi/api` resource
+#' \item A single string specifying the access token
+#'}
 #'
 #' @return DataFrame containing results of query
 #' @export
-execute_xmla_query <- function(workspace, dataset, query, access_token) {
+execute_xmla_query <- function(workspace, dataset, query, access_token = NULL) {
+  access_token <- init_access_token(access_token)
   auth_header <- get_auth_header(access_token)
 
   # Lookup GUIDs for the Workspace and overall capacity
@@ -265,8 +290,12 @@ execute_xmla_query <- function(workspace, dataset, query, access_token) {
 #' @param storage_mode The compute engine behaviour setting to be
 #' applied. Must be one of "Abf" (small semantic model format) or "PremiumFiles"
 #'  (large semantic model format).
-#' @param access_token The token generated with the correct PowerBI Dataflow
-#' permissions. Use get_az_tk('pbi_df') to create this token.
+#' @param access_token Token for authorising the connection to PowerBI. Valid options are:
+#' \itemize{
+#' \item `NULL`(default): Automatically generate via `qiverse.azure::get_az_tk('pbi_df')`
+#' \item An `AzureAuth` object: Will be refreshed for the `https://analysis.windows.net/powerbi/api` resource
+#' \item A single string specifying the access token
+#'}
 #'
 #' @return A response object from the PATCH request.
 #' @export
@@ -286,8 +315,9 @@ update_dataset_storage_mode <- function(
     workspace_name,
     dataset_name,
     storage_mode,
-    access_token
+    access_token = NULL
 ) {
+  access_token <- init_access_token(access_token)
   # Get dataset metadata
   dataset_metadata <- list_datasets(workspace_name, access_token)
   if (!(dataset_name %in% dataset_metadata$Dataset)) {

--- a/qiverse.powerbi/R/powerbi_dataflow.R
+++ b/qiverse.powerbi/R/powerbi_dataflow.R
@@ -1,5 +1,6 @@
-get_dataflow_metadata <- function(workspace_name, dataflow_name, access_token,
+get_dataflow_metadata <- function(workspace_name, dataflow_name, access_token = NULL,
                                   verbose = TRUE) {
+  access_token <- init_access_token(access_token)
   if (interactive() && isTRUE(verbose)) {
     message("Fetching dataflow metadata...")
   }
@@ -41,7 +42,8 @@ get_dataflow_metadata <- function(workspace_name, dataflow_name, access_token,
   target_dataflow[[1]]
 }
 
-get_table_metadata <- function(dataflow_id, table_name, access_token) {
+get_table_metadata <- function(dataflow_id, table_name, access_token = NULL) {
+  access_token <- init_access_token(access_token)
   # Now we can request detailed metadata for the dataflow, including column names
   # and types, as well the storage location of the actual CSV file
   all_tables <- httr::GET(url = paste0(get_cluster_url(access_token), "/metadata/v201606/cdsa/dataflows/", dataflow_id, "/contentandcache"),
@@ -58,7 +60,8 @@ get_table_metadata <- function(dataflow_id, table_name, access_token) {
   rtn
 }
 
-get_sas_key <- function(dataflow_id, table_name, access_token) {
+get_sas_key <- function(dataflow_id, table_name, access_token = NULL) {
+  access_token <- init_access_token(access_token)
   # While we have the URL for the table, we don't have 'permission' to
   # download it using our current access token. Instead, we need to use the
   # access token to request a Shared Access Signature (SAS). This SAS summarises
@@ -90,8 +93,12 @@ get_sas_key <- function(dataflow_id, table_name, access_token) {
 #' @param dataflow_name The name of the PowerBI Dataflow within the workspace.
 #' @param table_name The name of the table within the PowerBI Dataflow to be
 #' accessed.
-#' @param access_token The token generated with the correct PowerBI Dataflow
-#' permissions. Use get_az_tk('pbi_df') to create this token.
+#' @param access_token Token for authorising the connection to PowerBI. Valid options are:
+#' \itemize{
+#' \item `NULL`(default): Automatically generate via `qiverse.azure::get_az_tk('pbi_df')`
+#' \item An `AzureAuth` object: Will be refreshed for the `https://analysis.windows.net/powerbi/api` resource
+#' \item A single string specifying the access token
+#'}
 #' @param destfile Optional output filepath to save raw dataflow CSV file to.
 #' If `NULL` (default) the CSV is read into an R `data.frame`. If non-null,
 #' the CSV file is downloaded to specified filepath and the function has no return.
@@ -124,9 +131,10 @@ get_sas_key <- function(dataflow_id, table_name, access_token) {
 #' )
 #'}
 download_dataflow_table <- function(workspace_name, dataflow_name,
-                                    table_name, access_token,
+                                    table_name, access_token = NULL,
                                     destfile = NULL,
                                     verbose = TRUE) {
+  access_token <- init_access_token(access_token)
   target_dataflow <- get_dataflow_metadata(workspace_name, dataflow_name,
                                            access_token, verbose)
   # Extract
@@ -192,8 +200,12 @@ download_dataflow_table_impl <- function(dataflow_id, table_name, access_token, 
 #'
 #' @param workspace_name The PowerBI workspace name.
 #' @param dataflow_name The name of the PowerBI Dataflow within the workspace.
-#' @param access_token The token generated with the correct PowerBI Dataflow
-#' permissions. Use get_az_tk('pbi_df') to create this token.
+#' @param access_token Token for authorising the connection to PowerBI. Valid options are:
+#' \itemize{
+#' \item `NULL`(default): Automatically generate via `qiverse.azure::get_az_tk('pbi_df')`
+#' \item An `AzureAuth` object: Will be refreshed for the `https://analysis.windows.net/powerbi/api` resource
+#' \item A single string specifying the access token
+#'}
 #' @param verbose Whether to print status messages while the function is
 #' running. Default is TRUE.
 #'
@@ -214,10 +226,10 @@ download_dataflow_table_impl <- function(dataflow_id, table_name, access_token, 
 refresh_dataflow <- function(
   workspace_name,
   dataflow_name,
-  access_token,
+  access_token = NULL,
   verbose = TRUE
 ) {
-
+  access_token <- init_access_token(access_token)
   # Get dataflow metadata using utility function
   target_dataflow <- get_dataflow_metadata(workspace_name, dataflow_name,
                                            access_token, FALSE)
@@ -276,8 +288,12 @@ refresh_dataflow <- function(
 #' @param dataflow_name The name of the PowerBI Dataflow within the workspace.
 #' @param compute_engine The compute engine behaviour setting to be
 #' applied. Must be one of "computeOptimized", "computeOn" or "computeDisabled".
-#' @param access_token The token generated with the correct PowerBI Dataflow
-#' permissions. Use get_az_tk('pbi_df') to create this token.
+#' @param access_token Token for authorising the connection to PowerBI. Valid options are:
+#' \itemize{
+#' \item `NULL`(default): Automatically generate via `qiverse.azure::get_az_tk('pbi_df')`
+#' \item An `AzureAuth` object: Will be refreshed for the `https://analysis.windows.net/powerbi/api` resource
+#' \item A single string specifying the access token
+#'}
 #'
 #' @return A response object from the PATCH request.
 #' @export
@@ -298,8 +314,9 @@ update_dataflow_compute_engine <- function(
     workspace_name,
     dataflow_name,
     compute_engine,
-    access_token
+    access_token = NULL
 ) {
+  access_token <- init_access_token(access_token)
   # Check if compute engine behaviour is a valid option
   valid_compute_engine <- c("computeOptimized", "computeOn", "computeDisabled")
   if (!(compute_engine %in% valid_compute_engine)) {

--- a/qiverse.powerbi/R/utilities.R
+++ b/qiverse.powerbi/R/utilities.R
@@ -2,7 +2,8 @@ get_auth_header <- function(access_token) {
   httr::add_headers(Authorization = paste("Bearer", access_token))
 }
 
-get_cluster_url <- function(access_token) {
+get_cluster_url <- function(access_token = NULL) {
+  access_token <- init_access_token(access_token)
   cluster_details <-
     httr::GET(url = "https://api.powerbi.com/powerbi/globalservice/v201606/clusterdetails",
             config = get_auth_header(access_token),
@@ -283,4 +284,25 @@ clean_dataset_names <- function(df, curr_names = NULL) {
     curr_names <- names(df)
   }
   stats::setNames(df, gsub("(.*)?\\[(.*)\\]", "\\2", curr_names))
+}
+
+init_access_token <- function(access_token = NULL) {
+  if (is.character(access_token)) {
+    return(access_token)
+  }
+
+  if (inherits(access_token, "AzureToken")) {
+    access_token$resource <- "https://analysis.windows.net/powerbi/api"
+    access_token$refresh()
+  }
+
+  if (is.null(access_token)) {
+    if (!requireNamespace("qiverse.azure", quietly = TRUE)) {
+      stop("The `qiverse.azure` package is required for automatic authentication!",
+            call. = FALSE)
+    }
+    access_token <- qiverse.azure::get_az_tk("pbi_df")
+  }
+
+  access_token$credentials$access_token
 }

--- a/qiverse.powerbi/R/workspaces.R
+++ b/qiverse.powerbi/R/workspaces.R
@@ -1,11 +1,16 @@
 #' Request metadata for all Workspaces in Tenant
 #'
-#' @param access_token The token generated with the correct PowerBI Dataset
-#' permissions. Use get_az_tk('pbi_ds') to create this token.
+#' @param access_token Token for authorising the connection to PowerBI. Valid options are:
+#' \itemize{
+#' \item `NULL`(default): Automatically generate via `qiverse.azure::get_az_tk('pbi_df')`
+#' \item An `AzureAuth` object: Will be refreshed for the `https://analysis.windows.net/powerbi/api` resource
+#' \item A single string specifying the access token
+#'}
 #'
 #' @return DataFrame containing the names, GUIDs, and capacity GUIDs for all workspaces in tenant.
 #' @export
-list_workspaces <- function(access_token) {
+list_workspaces <- function(access_token = NULL) {
+  access_token <- init_access_token(access_token)
   base_url <- "https://api.powerbi.com/v1.0/myorg/groups"
   metadata_request <- httr::GET(url = base_url,
                                 config = get_auth_header(access_token),
@@ -29,12 +34,17 @@ list_workspaces <- function(access_token) {
 #' Request metadata for all dataflows in specified workspace
 #'
 #' @param workspace Name of the workspace containing dataflows
-#' @param access_token The token generated with the correct PowerBI Dataflow
-#' permissions. Use get_az_tk('pbi_df') to create this token.
+#' @param access_token Token for authorising the connection to PowerBI. Valid options are:
+#' \itemize{
+#' \item `NULL`(default): Automatically generate via `qiverse.azure::get_az_tk('pbi_df')`
+#' \item An `AzureAuth` object: Will be refreshed for the `https://analysis.windows.net/powerbi/api` resource
+#' \item A single string specifying the access token
+#'}
 #'
 #' @return DataFrame containing the names, GUIDs, and descriptions for all dataflows in workspace
 #' @export
-list_dataflows <- function(workspace, access_token) {
+list_dataflows <- function(workspace, access_token = NULL) {
+  access_token <- init_access_token(access_token)
   workspace_metadata <- qiverse.powerbi::list_workspaces(access_token)
   if (!(workspace %in% workspace_metadata$Workspace)) {
     stop("No workspace called: ", workspace, " in tenant!", call. = FALSE)
@@ -78,7 +88,8 @@ list_dataflows <- function(workspace, access_token) {
 }
 
 
-list_reports <- function(workspace_id, access_token) {
+list_reports <- function(workspace_id, access_token = NULL) {
+  access_token <- init_access_token(access_token)
   base_url <- paste0("https://api.powerbi.com/v1.0/myorg/groups/", workspace_id, "/reports")
   metadata_request <- httr::GET(url = base_url,
                                 config = get_auth_header(access_token),

--- a/qiverse.powerbi/man/download_dataflow_table.Rd
+++ b/qiverse.powerbi/man/download_dataflow_table.Rd
@@ -8,7 +8,7 @@ download_dataflow_table(
   workspace_name,
   dataflow_name,
   table_name,
-  access_token,
+  access_token = NULL,
   destfile = NULL,
   verbose = TRUE
 )
@@ -21,8 +21,12 @@ download_dataflow_table(
 \item{table_name}{The name of the table within the PowerBI Dataflow to be
 accessed.}
 
-\item{access_token}{The token generated with the correct PowerBI Dataflow
-permissions. Use get_az_tk('pbi_df') to create this token.}
+\item{access_token}{Token for authorising the connection to PowerBI. Valid options are:
+\itemize{
+\item \code{NULL}(default): Automatically generate via \code{qiverse.azure::get_az_tk('pbi_df')}
+\item An \code{AzureAuth} object: Will be refreshed for the \verb{https://analysis.windows.net/powerbi/api} resource
+\item A single string specifying the access token
+}}
 
 \item{destfile}{Optional output filepath to save raw dataflow CSV file to.
 If \code{NULL} (default) the CSV is read into an R \code{data.frame}. If non-null,

--- a/qiverse.powerbi/man/download_dataset_table.Rd
+++ b/qiverse.powerbi/man/download_dataset_table.Rd
@@ -11,7 +11,7 @@ download_dataset_table(
   dataset,
   table,
   method = "XMLA",
-  access_token
+  access_token = NULL
 )
 }
 \arguments{
@@ -23,8 +23,12 @@ download_dataset_table(
 
 \item{method}{The API to use for downloading the table. Valid values are "XMLA" (the default) and "REST"}
 
-\item{access_token}{The token generated with the correct PowerBI Dataset
-permissions. Use get_az_tk('pbi_ds') to create this token.}
+\item{access_token}{Token for authorising the connection to PowerBI. Valid options are:
+\itemize{
+\item \code{NULL}(default): Automatically generate via \code{qiverse.azure::get_az_tk('pbi_df')}
+\item An \code{AzureAuth} object: Will be refreshed for the \verb{https://analysis.windows.net/powerbi/api} resource
+\item A single string specifying the access token
+}}
 }
 \value{
 DataFrame containing downloaded table

--- a/qiverse.powerbi/man/execute_arrow_query.Rd
+++ b/qiverse.powerbi/man/execute_arrow_query.Rd
@@ -5,7 +5,7 @@
 \title{Execute a DAX query against a specified PowerBI Dataset using the REST
 Arrow API endpoint.}
 \usage{
-execute_arrow_query(workspace, dataset, query, access_token)
+execute_arrow_query(workspace, dataset, query, access_token = NULL)
 }
 \arguments{
 \item{workspace}{Name of the workspace containing dataflow}
@@ -14,8 +14,12 @@ execute_arrow_query(workspace, dataset, query, access_token)
 
 \item{query}{DAX query to execute}
 
-\item{access_token}{The token generated with the correct PowerBI Dataset
-permissions. Use get_az_tk('pbi_ds') to create this token.}
+\item{access_token}{Token for authorising the connection to PowerBI. Valid options are:
+\itemize{
+\item \code{NULL}(default): Automatically generate via \code{qiverse.azure::get_az_tk('pbi_df')}
+\item An \code{AzureAuth} object: Will be refreshed for the \verb{https://analysis.windows.net/powerbi/api} resource
+\item A single string specifying the access token
+}}
 }
 \value{
 DataFrame containing results of query

--- a/qiverse.powerbi/man/execute_rest_query.Rd
+++ b/qiverse.powerbi/man/execute_rest_query.Rd
@@ -5,7 +5,7 @@
 \title{Execute a DAX query against a specified PowerBI Dataset using the REST API
 endpoint.}
 \usage{
-execute_rest_query(workspace, dataset, query, access_token)
+execute_rest_query(workspace, dataset, query, access_token = NULL)
 }
 \arguments{
 \item{workspace}{Name of the workspace containing dataflow}
@@ -14,8 +14,12 @@ execute_rest_query(workspace, dataset, query, access_token)
 
 \item{query}{DAX query to execute}
 
-\item{access_token}{The token generated with the correct PowerBI Dataset
-permissions. Use get_az_tk('pbi_ds') to create this token.}
+\item{access_token}{Token for authorising the connection to PowerBI. Valid options are:
+\itemize{
+\item \code{NULL}(default): Automatically generate via \code{qiverse.azure::get_az_tk('pbi_df')}
+\item An \code{AzureAuth} object: Will be refreshed for the \verb{https://analysis.windows.net/powerbi/api} resource
+\item A single string specifying the access token
+}}
 }
 \value{
 DataFrame containing results of query

--- a/qiverse.powerbi/man/execute_xmla_query.Rd
+++ b/qiverse.powerbi/man/execute_xmla_query.Rd
@@ -5,7 +5,7 @@
 \title{Execute a DAX query against a specified PowerBI Dataset using the XMLA API
 endpoint.}
 \usage{
-execute_xmla_query(workspace, dataset, query, access_token)
+execute_xmla_query(workspace, dataset, query, access_token = NULL)
 }
 \arguments{
 \item{workspace}{Name of the workspace containing dataflow}
@@ -14,9 +14,12 @@ execute_xmla_query(workspace, dataset, query, access_token)
 
 \item{query}{DAX query to execute}
 
-\item{access_token}{The token generated with the correct PowerBI Dataset
-permissions. Use get_az_tk('pbi_df') or get_az_tk('pbi_df') to create
-this token.}
+\item{access_token}{Token for authorising the connection to PowerBI. Valid options are:
+\itemize{
+\item \code{NULL}(default): Automatically generate via \code{qiverse.azure::get_az_tk('pbi_df')}
+\item An \code{AzureAuth} object: Will be refreshed for the \verb{https://analysis.windows.net/powerbi/api} resource
+\item A single string specifying the access token
+}}
 }
 \value{
 DataFrame containing results of query

--- a/qiverse.powerbi/man/list_dataflows.Rd
+++ b/qiverse.powerbi/man/list_dataflows.Rd
@@ -4,13 +4,17 @@
 \alias{list_dataflows}
 \title{Request metadata for all dataflows in specified workspace}
 \usage{
-list_dataflows(workspace, access_token)
+list_dataflows(workspace, access_token = NULL)
 }
 \arguments{
 \item{workspace}{Name of the workspace containing dataflows}
 
-\item{access_token}{The token generated with the correct PowerBI Dataflow
-permissions. Use get_az_tk('pbi_df') to create this token.}
+\item{access_token}{Token for authorising the connection to PowerBI. Valid options are:
+\itemize{
+\item \code{NULL}(default): Automatically generate via \code{qiverse.azure::get_az_tk('pbi_df')}
+\item An \code{AzureAuth} object: Will be refreshed for the \verb{https://analysis.windows.net/powerbi/api} resource
+\item A single string specifying the access token
+}}
 }
 \value{
 DataFrame containing the names, GUIDs, and descriptions for all dataflows in workspace

--- a/qiverse.powerbi/man/list_datasets.Rd
+++ b/qiverse.powerbi/man/list_datasets.Rd
@@ -4,13 +4,17 @@
 \alias{list_datasets}
 \title{Request metadata for all datasets in specified workspace}
 \usage{
-list_datasets(workspace, access_token)
+list_datasets(workspace, access_token = NULL)
 }
 \arguments{
 \item{workspace}{Name of the workspace containing datasets}
 
-\item{access_token}{The token generated with the correct PowerBI Dataset
-permissions. Use get_az_tk('pbi_ds') to create this token.}
+\item{access_token}{Token for authorising the connection to PowerBI. Valid options are:
+\itemize{
+\item \code{NULL}(default): Automatically generate via \code{qiverse.azure::get_az_tk('pbi_df')}
+\item An \code{AzureAuth} object: Will be refreshed for the \verb{https://analysis.windows.net/powerbi/api} resource
+\item A single string specifying the access token
+}}
 }
 \value{
 DataFrame containing the names, GUIDs, and descriptions for all datasets in workspace

--- a/qiverse.powerbi/man/list_workspaces.Rd
+++ b/qiverse.powerbi/man/list_workspaces.Rd
@@ -4,11 +4,15 @@
 \alias{list_workspaces}
 \title{Request metadata for all Workspaces in Tenant}
 \usage{
-list_workspaces(access_token)
+list_workspaces(access_token = NULL)
 }
 \arguments{
-\item{access_token}{The token generated with the correct PowerBI Dataset
-permissions. Use get_az_tk('pbi_ds') to create this token.}
+\item{access_token}{Token for authorising the connection to PowerBI. Valid options are:
+\itemize{
+\item \code{NULL}(default): Automatically generate via \code{qiverse.azure::get_az_tk('pbi_df')}
+\item An \code{AzureAuth} object: Will be refreshed for the \verb{https://analysis.windows.net/powerbi/api} resource
+\item A single string specifying the access token
+}}
 }
 \value{
 DataFrame containing the names, GUIDs, and capacity GUIDs for all workspaces in tenant.

--- a/qiverse.powerbi/man/refresh_dataflow.Rd
+++ b/qiverse.powerbi/man/refresh_dataflow.Rd
@@ -4,15 +4,24 @@
 \alias{refresh_dataflow}
 \title{Refresh PowerBI Dataflow}
 \usage{
-refresh_dataflow(workspace_name, dataflow_name, access_token, verbose = TRUE)
+refresh_dataflow(
+  workspace_name,
+  dataflow_name,
+  access_token = NULL,
+  verbose = TRUE
+)
 }
 \arguments{
 \item{workspace_name}{The PowerBI workspace name.}
 
 \item{dataflow_name}{The name of the PowerBI Dataflow within the workspace.}
 
-\item{access_token}{The token generated with the correct PowerBI Dataflow
-permissions. Use get_az_tk('pbi_df') to create this token.}
+\item{access_token}{Token for authorising the connection to PowerBI. Valid options are:
+\itemize{
+\item \code{NULL}(default): Automatically generate via \code{qiverse.azure::get_az_tk('pbi_df')}
+\item An \code{AzureAuth} object: Will be refreshed for the \verb{https://analysis.windows.net/powerbi/api} resource
+\item A single string specifying the access token
+}}
 
 \item{verbose}{Whether to print status messages while the function is
 running. Default is TRUE.}

--- a/qiverse.powerbi/man/update_dataflow_compute_engine.Rd
+++ b/qiverse.powerbi/man/update_dataflow_compute_engine.Rd
@@ -8,7 +8,7 @@ update_dataflow_compute_engine(
   workspace_name,
   dataflow_name,
   compute_engine,
-  access_token
+  access_token = NULL
 )
 }
 \arguments{
@@ -19,8 +19,12 @@ update_dataflow_compute_engine(
 \item{compute_engine}{The compute engine behaviour setting to be
 applied. Must be one of "computeOptimized", "computeOn" or "computeDisabled".}
 
-\item{access_token}{The token generated with the correct PowerBI Dataflow
-permissions. Use get_az_tk('pbi_df') to create this token.}
+\item{access_token}{Token for authorising the connection to PowerBI. Valid options are:
+\itemize{
+\item \code{NULL}(default): Automatically generate via \code{qiverse.azure::get_az_tk('pbi_df')}
+\item An \code{AzureAuth} object: Will be refreshed for the \verb{https://analysis.windows.net/powerbi/api} resource
+\item A single string specifying the access token
+}}
 }
 \value{
 A response object from the PATCH request.

--- a/qiverse.powerbi/man/update_dataset_storage_mode.Rd
+++ b/qiverse.powerbi/man/update_dataset_storage_mode.Rd
@@ -8,7 +8,7 @@ update_dataset_storage_mode(
   workspace_name,
   dataset_name,
   storage_mode,
-  access_token
+  access_token = NULL
 )
 }
 \arguments{
@@ -20,8 +20,12 @@ update_dataset_storage_mode(
 applied. Must be one of "Abf" (small semantic model format) or "PremiumFiles"
 (large semantic model format).}
 
-\item{access_token}{The token generated with the correct PowerBI Dataflow
-permissions. Use get_az_tk('pbi_df') to create this token.}
+\item{access_token}{Token for authorising the connection to PowerBI. Valid options are:
+\itemize{
+\item \code{NULL}(default): Automatically generate via \code{qiverse.azure::get_az_tk('pbi_df')}
+\item An \code{AzureAuth} object: Will be refreshed for the \verb{https://analysis.windows.net/powerbi/api} resource
+\item A single string specifying the access token
+}}
 }
 \value{
 A response object from the PATCH request.


### PR DESCRIPTION
@pli9 What do you think of this pattern for our Azure functions? This way the separate token construction isn't necessary (but is still an option). Combined with `qiverse.azure::get_az_tk` also supporting databricks, could help simplify a lot of the flow